### PR TITLE
Update map collision materials

### DIFF
--- a/soulstruct_havok/fromsoft/shared/map_collision.py
+++ b/soulstruct_havok/fromsoft/shared/map_collision.py
@@ -45,20 +45,39 @@ class MapCollisionMaterial(IntEnum):
 
     TODO: Not confirmed for Demon's Souls (Havok 5.5.0) but looks good so far.
     """
-    Default = 0  # unknown usage
-    Rock = 1  # actual rocks, bricks
-    Stone = 2  # e.g. walls
-    Grass = 3  # e.g. forest ground
+    Dummy = 0  # unknown usage
+    OutdoorStone = 1  # actual rocks, bricks
+    IndoorStone = 2  # e.g. walls
+    Soil = 3  # e.g. dirt, light grass
     Wood = 4  # e.g. logs
-    LoResGround = 5  # unknown purpose; seems to randomly replace other ground types in lo-res
-    # TODO: 6 appears in unused/prototype/corrupted h1000B2A10 (Firelink).
+    Grass = 5  # used for heavy grass/foliage
+    Gravel = 6
     Snow = 7
+    Ice = 8  # Used for crystals in Crystal Caves
     Metal = 9  # e.g. grilles
-
-    # rough
+    Sand = 10
+    Bone = 11
+    Ash = 12
+    # no params for 13
+    RottenWood = 14  # Used for the roof you fight Bell Gargoyles on.
+    BigTree = 15  # Some wood in the Great Hollow
+    # no params for 16
+    SnowNoFootprint = 17
+    # no params for 18
+    WaterSlide = 19
     ShallowWater = 20
     DeepWater = 21
-    Killplane = 29  # also deathcam trigger, or lethal fall, etc.
+    Mucus = 22  # e.g. slime in The Depths
+    PoisonSwamp = 23
+    Mud = 24
+    CoalTar = 25  # Used for the area at the bottom of Sen's Fortress with the Titanite Demons
+    ChimeraSwamp = 26
+    Lava = 27
+    Carpet = 28
+    Empty = 29  # Used for anything that is not meant to have a visual (killplane, deathcam, invisible wall, etc.)
+    # No params for 30-33
+    Wood2 = 34  # Identical param name to Wood, slightly different particles?
+    # No params for 35-36
     Trigger = 40  # other triggers?
 
 


### PR DESCRIPTION
This update is based heavily on the names of the parameters in HitMtrlParam that directly match the collision material indices, as well as some testing in game.
HitMtrlParam is present in all games, except DeS and DS2. From DS3 onwards they added new params to directly control what SFX and SE is used for each, but it appears to still be the same?
I have not tested it but the params are still present and some of them even seem to be in the same ID as DS1 in Nightreign!
Although despite this, I don't think this list should be used outright for other games, since they may have made changes.

Where possible the names directly match a translation of the param (done mostly using a kanji to english dictionary rather than machine translation), although for clarity I think some of the names could be changed to better reflect where they are used rather than what they're named (like ChimeraSwamp, i have no clue where that name came from, but that is what it says in Japanese)
If this PR gets merged as is, `_FLVER_REGEX_TO_HKX_MATERIAL` in Soulstruct-Blender will need to be updated to change Stone to IndoorStone, and Rock to OutdoorStone.

The only one that I left as it was is index 40 "Trigger", mostly because I'm still not sure what it actually *does*. Apparently its param name translates to "For Dobon SFX" but I don't know what that is. It is used in Darkroot for killplanes it seems like, and in one collision mesh in Oolacile (out of bounds and copied from darkroot?).

it seems like 100-500 & 700-900 are all valid "modifiers" for collision. I'm not entirely sure if its all just friction or what, I made a very small test map with a very slight angle and only noticed a difference at 400 and 500.
600 appears to be invalid, causing the collision to be disabled. 700-900 did not seem to have any extra friction, so it needs more testing to see if they do anything.

I also noticed the comment that says "TODO: Not confirmed for Demon's Souls (Havok 5.5.0) but looks good so far."
I haven't checked DeS, but this seems relatively likely in some manner. Though I don't think its quite the same, since DeS lacks HitMtrlParam, so its potentially hardcoded.
Another thing I've noticed which influences my thought is the collision in the Painted World. Being one of the first maps they made, it seems pretty likely that it was made using the same version of havok (or at least they were using the same collision code) as DeS.
It's a bit hard to describe, but the Painted World's collision is extremely odd and I at first thought there was some pattern to it, since faces at odd angles seemed to be the ones with weird materials, but I can't figure it out.
Many of the faces which are flat have normal collision materials that seem to match the intent, but then there's doorways and staircases made out of poison swamp and mud.

It seems like maybe in DeS hi hit is determined by bit 5 of the material index? if you take a messed up collision (seemingly always in hi hit) and then flip bit 5 then you'll almost always get the index of the material used for the same area (or nearby areas) in lo hit.
Although there's also other times where the hi hit has an incorrect material with an index under 10 and they don't have a 5th bit to flip. it might be an endianness issue and I'm calculating this incorrectly? The point is that the Painted World's collisions are extremely messed up and odd, and we know that it is one of the earliest maps.

With all that being said, here's the current list of collisions, along with some additional notes I have on them.

<details><summary>Details</summary>
<p>

- Dummy: 0 - Appears to be essentially nothing, I don't think this is used intentionally since for triggers and the like From seems to prefer Empty (29)
- OutdoorStone: 1 - Formerly "rock", the official param name is "Stone (Outdoor)". The distinction between outdoor and indoor stone is odd, for the most part this one is used for everything
- IndoorStone: 2 - Formerly "stone", the official param name is "Stone (Indoor)". As mentioned above this one is odd, I'm not sure what to call it. Used for all of the Depths, some parts of Tomb of the Giants and Lost Izalith, including the Bed of Chaos arena.
- Soil: 3 - Dirt might be a batter name, Used all over the place, even in places that you'd think they wouldn't like Darkroot 
- Wood: 4
- Grass: 5 - Their usage of this is a bit odd so I'm not surprised that you labelled it as seemingly randomly replacing other ground types. It seems like they use this mostly in areas with lots of big bushy grass & foliage models. A good example of this is the graveyard in Firelink Shrine, especially down by the giant skeletons, the sound it plays does sound a lot more like you're wading through plants than it does just walking on a bit of grass, so it makes sense. Although also this is used a lot in the Great Hollow
- Gravel: 6 - Used in Duke's Archives, Undead Burg, Painted World, Oolacile, Demon Ruins, Chasm of the Abyss and Tomb of the Giants, mostly out of bounds or overlappin other collision. The FFX files for this collision type are only loaded in m13_01 (Tomb of the Giants)
- Snow: 7 - Used in Undead Asylum, Sen's Fortress (??), and Painted World, but the FFX file is only loaded in m11 (Painted World) & m10_00 (The Depths). latter is maybe a typo? maybe whoever did it thought undead asylum was 10_00 since its the first playable map
- Ice: 8 - Not really ice? Used in the Crystal Caves for all of the crystals, and it makes a weird kind of magic-y noise when you hit it. FFX file only loaded in m17 (Duke's/Crystal Caves). might be worth just renaming this to "Crystal"
- Metal: 9
- Sand: 10 - FFX file only loaded in map ID 13 (Catacombs, Tomb of the Giants, and Great Hollow/Ash Lake, probably only used in the latter)
- Bone: 11
- Ash: 12 - FFX file only loaded in map ID 18 (Kiln & Undead Asylum)
- N/A: 13 - No params or FFX files I could find
- RottenWood: 14 - Rotten Wood is the name of the param, but its only used to my knowledge for the roof you fight Bell Gargoyles on. Smithbox community names lists this as "roof tiles", which I guess could be more accurate? FFX file only loaded in m10_01 (Undead Burg/Parish)
- BigTree: 15 - Used for some wood in the Great Hollow. FFX file only loaded in m13_02 (Great Hollow/Ash Lake)
- N/A: 16 - No params, but it has FFX files loaded in the Depths, haven't investigated.
- SnowNoFootprint: 17 - Self-explanatory, used in the Painted World for areas where footsteps would look odd (like snowy rubble). FFX only loaded in m11 (Painted World)
- N/A: 18 - No params or FFX files I could find
- WaterSlide: 19 - Used for the slide in the Depths, the param is just named "Water (Slide)". no FFX files.
- ShallowWater: 20 - Param name is more like "Water (puddle)" but Shallow Water is a good name.
- DeepWater: 21 - Param name is more like "Water (ankle level), but Deep Water is a good name. Param also has increased "audio" volume (for enemies to hear you) from 1 to 3.
- Mucus: 22 - Slime in The Depths used in the Gaping Dragon's arena, also used in the Chaos Eater maze in Lost Izalith and Seath's first arena in Duke's Archives, although the FFX file is only loaded in m10_00 (The Depths). Slime might just be a clearer name.
- PoisonSwamp: 23 - Actual name. Adds the SpEffect for DeepWater. FFX file only present in map ID 14 (Blighttown, Demon Ruins/Lost Izalith)
- Mud: 24 - Seemingly only used by accident in a few spots. Adds the SpEffect for DeepWater
- CoalTar: 25 - Used for the bottom of Sen's Fortress in the area with all the Titanite Demons, Coal Tar is the actual param name. Adds the SpEffect for DeepWater. FFX file only present in m15_00 (Sen's Fortress).
- ChimeraSwamp: 26 - I'm not sure where the name comes from, used in The Depths for the slime that isn't in the Gaping Dragon's arena, no FFX files
- Lava: 27 - FFX file only present in m14_01 (Demon Ruins/Lost Izalith)
- Carpet: 28 - FFX file only present in m15_01 (Anor Londo)
- Empty: 29 - Used for anything that is not meant to have a visual, although it appears that there is FFX associated with it? Used for killplane, deathcam trigger, lethal fall, etc. Also used for hands-on collision fixes like invis walls if they didn't want a particle effect. The full param name is approximately "Empty (no visuals)". I don't fully understand this since I feel like Dummy would serve the same purpose?
- N/A: 30-33 - No params or FFX files I could find
- Wood2: 34 - Identical param name to Wood, slightly different particles? Not used anywhere from what I could tell.
- N/A: 35-36 - No params or FFX files I could find
- Trigger: 40 - Param is named "For Dobon SFX" apparently, whatever that means. Only used in Darkroot & Oolacile for killplanes? it looks like there is some FFX files associated with it but I'm not sure how to trigger them.
</p>
</details> 

I also made a new color list for Soulstruct-Blender, but after a tiny bit of usage it seems that I am not good at picking out colors and it is quite hard to distinguish many of the materials (most of them are browns and greys).
In case it helps to pick out some better colors though:
<details><summary>colors</summary>
<p>

```
HKX_MATERIAL_COLORS = {
    0: (0, 0, 100),     # dummy (white)
    1: (24, 75, 70),    # outdoor stone (orange)
    2: (0, 0, 10),      # indoor stone (dark grey)
    3: (28, 53, 62),    # soil (light brown)
    4: (36, 86, 43),    # wood (dark brown)
    5: (114, 58, 57),   # grass (green)
    6: (0, 0, 70),      # gravel (light grey)
    7: (180, 5, 90),    # snow (grey-white)
    8: (180, 43, 91),   # ice (very light blue-grey)
    9: (179, 66, 64),   # metal (cyan)
    10: (45, 31, 100),  # sand (tan)
    11: (38, 25, 46),   # bone (grey-brown? I am bad at colors)
    12: (0, 0, 0),      # ash (black)

    14: (54, 81, 27),   # rotten wood (darker brown)
    15: (36, 81, 57),   # big tree (brown)

    17: (180, 5, 90),   # snow (no footprints) (grey-white) (should this have a different color than snow?)

    19: (200, 65, 64),  # water slide (a bit lighter blue)
    20: (214, 75, 64),  # under shallow water (light blue)
    21: (230, 85, 64),  # under deep water (dark blue)
    22: (76, 82, 74),   # mucus (yellow-green)
    23: (284, 90, 74),  # poison swamp (purple)
    24: (47, 92, 73),   # mud (yellow-brown)
    25: (276, 84, 38),  # coal tar (dark purple)
    26: (321, 87, 58),  # chimera swamp (magenta)
    27: (25, 89, 97),   # lava (orange)
    28: (2, 73, 85),    # carpet (pale red)
    29: (111, 78, 95),  # empty (light green)

    34: (36, 86, 43),   # wood2 (dark brown) (same color as wood)

    40: (50, 68, 80),  # trigger only (yellow)
}
```

</p>
</details>  
